### PR TITLE
Fix overlapping in ProjectCards and Popup, enable private tags

### DIFF
--- a/src/components/PopUp.jsx
+++ b/src/components/PopUp.jsx
@@ -6,17 +6,16 @@ const SeeProjectIcon = '/see-live-icon.png';
 const SeeCodeIcon = '/see-source-icoin.png';
 
 const PopUp = ({ project, handlePopUp }) => {
+  const isPrivate = project.visibility === 'private';
+
   return (
     <div
       id="pop-up-background"
-      className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center backdrop-blur-md min-h-screen
-    px-4 md:p-6 overflow-y-auto z-40
-    "
+      className="fixed inset-0 bg-black/50 flex justify-center items-start md:items-center backdrop-blur-md min-h-screen px-4 py-6 overflow-y-auto z-40"
     >
       <div
         id="pop-up-container"
-        className="bg-white rounded-lg p-4 z-10 flex flex-col gap-4 max-h-full overflow-y-auto 
-      md:aspect-square"
+        className="bg-white rounded-lg p-4 md:p-6 z-10 flex flex-col gap-4 w-full max-w-5xl max-h-[calc(100vh-3rem)] overflow-y-auto"
       >
         <div id="pop-up-header">
           <div
@@ -30,40 +29,51 @@ const PopUp = ({ project, handlePopUp }) => {
               <img src={CloseIcon} alt="Close Icon" />
             </button>
           </div>
-          <div className="flex items-center font-semibold text-sm">
+          <div className="flex flex-wrap items-center gap-2 font-semibold text-sm">
             <span className="text-[#344563]">{project.company}</span>
             <ul className="flex list-disc gap-7 text-[#7A869A] pl-5">
               <li>{project.typeOfDev}</li>
               <li>{project.date}</li>
             </ul>
+            {isPrivate && (
+              <span className="rounded-full bg-[#EBF0FF] px-3 py-1 text-xs font-bold uppercase tracking-wide text-[#396DF2]">
+                Private case study
+              </span>
+            )}
           </div>
         </div>
         <div
           id="pop-up-img-frame"
-          className="container h-10 sm:h-4/6 w-full bg-slate-100 min-w-[295px] min-h-[220px]"
+          className="w-full bg-slate-100 min-h-[220px] md:min-h-[320px] rounded-lg overflow-hidden"
         >
           <img
             src={project.img}
             alt={`Screenshot of ${project.name}`}
-            className="object-cover w-full h-full rounded-lg"
+            className="object-cover w-full h-full"
           />
         </div>
-        <div id="pop-up-body" className="flex flex-col sm:flex-row sm:h-2/6">
-          <p className="text-[#344563] sm:w-3/5">{project.descriptionDesk}</p>
-          <div className="flex flex-col gap-4 sm:w-2/5">
+        <div id="pop-up-body" className="flex flex-col gap-4 md:grid md:grid-cols-[1.6fr_1fr] md:items-start">
+          <p className="text-[#344563] leading-7">{project.descriptionDesk}</p>
+          <div className="flex flex-col gap-4">
             <div className="flex flex-wrap gap-2">
-              {project.technologies.map((technology) => {
-                return <Tag key={technology} text={technology} />;
-              })}
+              {project.technologies.map((technology) => (
+                <Tag key={technology} text={technology} />
+              ))}
             </div>
-            <div className="flex items-center justify-center gap-2">
-              <a href={project.liveVersion} target="_blank" rel="noreferrer">
-                <Btn text="See Live" icon={SeeProjectIcon} />
-              </a>
-              <a href={project.source} target="_blank" rel="noreferrer">
-                <Btn text="See Source" icon={SeeCodeIcon} />
-              </a>
-            </div>
+            {isPrivate ? (
+              <div className="rounded-lg border border-[#DFE1E6] bg-[#F8F9FB] p-4 text-sm text-[#344563]">
+                Source code and live access are private due to confidentiality.
+              </div>
+            ) : (
+              <div className="flex items-center justify-center gap-2">
+                <a href={project.liveVersion} target="_blank" rel="noreferrer">
+                  <Btn text="See Live" icon={SeeProjectIcon} />
+                </a>
+                <a href={project.source} target="_blank" rel="noreferrer">
+                  <Btn text="See Source" icon={SeeCodeIcon} />
+                </a>
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -81,8 +91,9 @@ PopUp.propTypes = {
     img: PropTypes.string.isRequired,
     descriptionDesk: PropTypes.string.isRequired,
     technologies: PropTypes.arrayOf(PropTypes.string).isRequired,
-    liveVersion: PropTypes.string.isRequired,
-    source: PropTypes.string.isRequired,
+    visibility: PropTypes.string,
+    liveVersion: PropTypes.string,
+    source: PropTypes.string,
   }).isRequired,
   handlePopUp: PropTypes.func.isRequired,
 };

--- a/src/components/PopUp.jsx
+++ b/src/components/PopUp.jsx
@@ -44,12 +44,12 @@ const PopUp = ({ project, handlePopUp }) => {
         </div>
         <div
           id="pop-up-img-frame"
-          className="w-full bg-slate-100 min-h-[220px] md:min-h-[320px] rounded-lg overflow-hidden"
+          className="w-full bg-slate-100 min-h-[220px] md:min-h-[320px] rounded-lg overflow-hidden flex items-center justify-center p-4 md:p-6"
         >
           <img
             src={project.img}
             alt={`Screenshot of ${project.name}`}
-            className="object-cover w-full h-full"
+            className="object-contain block w-auto h-auto max-w-full max-h-full"
           />
         </div>
         <div id="pop-up-body" className="flex flex-col gap-4 md:grid md:grid-cols-[1.6fr_1fr] md:items-start">

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -7,6 +7,7 @@ import PopUp from './PopUp';
 const ProjectCard = ({ project, index, isActive }) => {
   const [popUp, setPopUp] = useState(false);
   const [animate, setAnimate] = useState(false);
+  const isPrivate = project.visibility === 'private';
 
   const desktopFlexDirection = index % 2 === 0 ? 'md:flex-row' : 'md:flex-row-reverse';
 
@@ -50,15 +51,15 @@ const ProjectCard = ({ project, index, isActive }) => {
           className="
             container bg-slate-100 sm:overflow-hidden flex items-center justify-center 
             md:max-h-[448px] w-full md:w-1/2 min-w-[295px] min-h-[220px] md:min-w-[220px] 
-            rounded-md border-2 border-[#DFE1E6]
+            rounded-md border-2 border-[#DFE1E6] p-3 md:p-4
           "
         >
           <img
             src={project.img}
             alt={`Screenshot of ${project.name}`}
             className={`
-              object-cover sm:object-contain justify-center items-center 
-              w-full h-full rounded-lg 
+                object-contain block mx-auto my-auto
+                w-full h-full max-w-full max-h-full rounded-lg
               ${animate ? 'transform translate-y-0' : 'transform translate-y-full'} 
               transition-transform ease-in-out duration-500
             `}
@@ -78,12 +79,17 @@ const ProjectCard = ({ project, index, isActive }) => {
             {project.name}
           </h5>
 
-          <div className="flex items-center py-2 font-semibold text-sm">
+          <div className="flex flex-wrap items-center gap-2 py-2 font-semibold text-sm">
             <span className="text-[#344563]">{project.company}</span>
             <ul className="flex list-disc gap-7 text-[#7A869A] pl-5">
               <li>{project.typeOfDev}</li>
               <li>{project.date}</li>
             </ul>
+            {isPrivate && (
+              <span className="rounded-full bg-[#EBF0FF] px-3 py-1 text-xs font-bold uppercase tracking-wide text-[#396DF2]">
+                Private case study
+              </span>
+            )}
           </div>
 
           <p className="card-text text-[#344563]">{project.description}</p>
@@ -95,7 +101,7 @@ const ProjectCard = ({ project, index, isActive }) => {
           </ul>
 
           <div>
-            <Btn text="See Project" onClick={handlePopUp} />
+            <Btn text={isPrivate ? 'View Case Study' : 'See Project'} onClick={handlePopUp} />
           </div>
         </div>
       </div>

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -59,7 +59,7 @@ const ProjectCard = ({ project, index, isActive }) => {
             alt={`Screenshot of ${project.name}`}
             className={`
                 object-contain block mx-auto my-auto
-                w-full h-full max-w-full max-h-full rounded-lg
+                w-auto h-auto max-w-full max-h-full rounded-lg
               ${animate ? 'transform translate-y-0' : 'transform translate-y-full'} 
               transition-transform ease-in-out duration-500
             `}


### PR DESCRIPTION
## Pull Request: Improve Project Cards and Popup Layout + Support Private Projects

### Summary

This PR enhances the Projects section by improving card and popup layouts, fixing image alignment issues, and adding support for private/confidential projects.

### Changes Included

#### Project Cards

* Fixed image overlapping and sizing issues.
* Centered project images inside cards.
* Added consistent padding and improved responsive layout.
* Added **Private Case Study** badge for confidential projects.
* Updated CTA button text:

  * Public projects: **See Project**
  * Private projects: **View Case Study**

#### Popup Modal

* Improved popup positioning and vertical centering.
* Increased max width and optimized responsive spacing.
* Fixed scrolling behavior for smaller screens.
* Centered popup images and changed image fit behavior for better display.
* Improved content layout using responsive grid structure.

#### Private Project Support

* Added conditional handling for projects marked as private.
* Hides live/source links for confidential work.
* Displays professional confidentiality notice instead.

#### UI / UX Improvements

* Better spacing for metadata tags and technology badges.
* Cleaner layout across mobile and desktop.
* More polished and professional project presentation.

### Goal

Create a cleaner project showcase experience while allowing confidential client work to be presented professionally without exposing restricted links or source code.
